### PR TITLE
[codex] Add self-validating handover pack

### DIFF
--- a/.github/workflows/validate-handover.yml
+++ b/.github/workflows/validate-handover.yml
@@ -1,0 +1,44 @@
+name: validate-handover
+
+on:
+  pull_request:
+    paths:
+      - "handover/stage-1-self-validating/**"
+      - ".github/workflows/validate-handover.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate local pack
+        working-directory: handover/stage-1-self-validating
+        run: make refresh
+      - name: Install OPA
+        run: |
+          curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
+          chmod +x opa
+          sudo mv opa /usr/local/bin/opa
+      - name: Evaluate Rego policy
+        working-directory: handover/stage-1-self-validating
+        run: make validate-opa
+      - name: Upload handover status
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: handover-status
+          path: |
+            handover/stage-1-self-validating/handover.status
+            handover/stage-1-self-validating/handover.status.json
+      - name: Release note line
+        if: always()
+        working-directory: handover/stage-1-self-validating
+        run: echo "Handover validation: $(cat handover.status 2>/dev/null || echo FAIL)"

--- a/handover/stage-1-self-validating/.gitignore
+++ b/handover/stage-1-self-validating/.gitignore
@@ -1,0 +1,5 @@
+handover.status
+handover.status.json
+handover.fail-demo.status
+handover.fail-demo.status.json
+.deny.txt

--- a/handover/stage-1-self-validating/Makefile
+++ b/handover/stage-1-self-validating/Makefile
@@ -1,0 +1,62 @@
+PYTHON ?= python3
+OPA ?= opa
+
+HANDOVER := handover/handover.json
+DIGESTS := handover/digests.json
+ATTESTATION := handover/attestations/handover.intoto.json
+SCHEMA := schema/handover.schema.json
+STATUS := handover.status
+STATUS_JSON := handover.status.json
+
+.PHONY: refresh digests attest validate validate-opa fail-demo clean validate-strict-provenance
+
+refresh: digests attest validate
+
+digests:
+	$(PYTHON) scripts/update_digests.py \
+	  --evidence-dir handover/evidence \
+	  --output $(DIGESTS)
+
+attest: digests
+	$(PYTHON) scripts/create_local_attestation.py \
+	  --handover $(HANDOVER) \
+	  --digests $(DIGESTS) \
+	  --output $(ATTESTATION)
+
+validate:
+	$(PYTHON) scripts/validate_handover.py \
+	  --handover $(HANDOVER) \
+	  --digests $(DIGESTS) \
+	  --attestation $(ATTESTATION) \
+	  --schema $(SCHEMA) \
+	  --status $(STATUS) \
+	  --status-json $(STATUS_JSON)
+
+validate-opa:
+	$(OPA) eval \
+	  --format pretty \
+	  --data policy/handover.rego \
+	  --data $(DIGESTS) \
+	  --input $(HANDOVER) \
+	  'data.handover.deny'
+
+fail-demo:
+	$(PYTHON) scripts/validate_handover.py \
+	  --handover $(HANDOVER) \
+	  --digests $(DIGESTS) \
+	  --attestation $(ATTESTATION) \
+	  --schema $(SCHEMA) \
+	  --status handover.fail-demo.status \
+	  --status-json handover.fail-demo.status.json \
+	  --inject-failure missing-safety-evidence \
+	  --expect-fail
+
+validate-strict-provenance:
+	@echo "Set ARTIFACT and GITHUB_REPOSITORY, then replace this target with gh attestation verify or cosign verify-attestation for the real produced artifact."
+	@test -n "$$ARTIFACT"
+	@test -n "$$GITHUB_REPOSITORY"
+	gh attestation verify "$$ARTIFACT" --repo "$$GITHUB_REPOSITORY"
+
+clean:
+	rm -f $(STATUS) $(STATUS_JSON) handover.fail-demo.status handover.fail-demo.status.json
+

--- a/handover/stage-1-self-validating/README.md
+++ b/handover/stage-1-self-validating/README.md
@@ -1,0 +1,71 @@
+# Mountain Refuge Stage 1 Self-Validating Handover
+
+This is a small example handover pack for the first stage design of a mountain refuge built on a crag. It turns the handover into a declarative pack with checks that fail closed:
+
+- schema check: does the pack have the required shape?
+- policy check: are the required roles, gates, evidence classes, and digests present?
+- digest check: do the listed evidence hashes match the files on disk?
+- provenance check: does a minimal in-toto/SLSA-style statement bind the handover and evidence together?
+
+The example is deliberately local-first. It includes the OPA/Rego policy, but also a small Python validator so the pack can be tried without installing AJV, OPA, or cosign first.
+
+## Quick Start
+
+From this folder:
+
+```sh
+make refresh
+make validate
+make fail-demo
+```
+
+Expected result:
+
+- `make refresh` regenerates evidence digests and a local in-toto statement.
+- `make validate` writes `PASS` to `handover.status`.
+- `make fail-demo` simulates a missing required evidence class and writes `FAIL` to `handover.fail-demo.status`, while returning success because the failure was expected.
+
+## Pack Layout
+
+```text
+handover/
+  handover.json
+  digests.json
+  attestations/
+    handover.intoto.json
+  evidence/
+    access-logistics-and-rescue.md
+    cost-schedule-baseline.md
+    environment-planning-note.md
+    handover-operating-notes.md
+    risk-register.md
+    site-context-and-constraints.md
+    stage-1-concept-design.md
+    structural-safety-basis.md
+policy/
+  handover.rego
+schema/
+  handover.schema.json
+  digests.schema.json
+scripts/
+  create_local_attestation.py
+  update_digests.py
+  validate_handover.py
+```
+
+## What The Board Sees
+
+The board-facing signal is intentionally boring:
+
+```text
+handover.status = PASS
+```
+
+The audit detail is in `handover.status.json`, which records the checked pack, result, and denial reasons if the pack fails.
+
+## Strict CI Path
+
+The included workflow in `.github/workflows/validate.yml` is written as if this example folder is the root of a repo. It runs the local validator and can also run OPA when available.
+
+For a real project, replace the local `handover/attestations/handover.intoto.json` with a GitHub artifact attestation or cosign/SLSA provenance statement emitted by the producing workflow, then wire the strict verification command into `make validate-strict-provenance`.
+

--- a/handover/stage-1-self-validating/handover/attestations/handover.intoto.json
+++ b/handover/stage-1-self-validating/handover/attestations/handover.intoto.json
@@ -1,0 +1,81 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://example.org/handover/stage-1-design",
+      "externalParameters": {
+        "handover_id": "gimmer-refuge-stage1-001",
+        "project": "Gimmer Crag Mountain Refuge",
+        "stage": "stage_1_design"
+      }
+    },
+    "materials": [
+      {
+        "digest": {
+          "sha256": "5f1d7134401a396cd317581333fc9264c585cbeb0ed58e155c59d67afcd1a9bd"
+        },
+        "uri": "handover/evidence/site-context-and-constraints.md"
+      },
+      {
+        "digest": {
+          "sha256": "4ee464355550fdb16dca93c2810ca014b5ff43ef0b51668b5d9f8efddef3de88"
+        },
+        "uri": "handover/evidence/access-logistics-and-rescue.md"
+      },
+      {
+        "digest": {
+          "sha256": "b497ef5f544420ffcd719436b5a6e2cc3aeb68392f05974defec9930d5839dc2"
+        },
+        "uri": "handover/evidence/stage-1-concept-design.md"
+      },
+      {
+        "digest": {
+          "sha256": "3b3143b3bab6823738f1097e30a5d2b5e200aa7651d425d33af91a4b3d5c42a8"
+        },
+        "uri": "handover/evidence/structural-safety-basis.md"
+      },
+      {
+        "digest": {
+          "sha256": "38f671ddff6a62de874d441363782612b8884e239aaa8e9d4082315e0a1fac74"
+        },
+        "uri": "handover/evidence/environment-planning-note.md"
+      },
+      {
+        "digest": {
+          "sha256": "8e96176c9b6ef4bf06529a8022d37537460113bdc1a0bd6b699d31af44bca634"
+        },
+        "uri": "handover/evidence/cost-schedule-baseline.md"
+      },
+      {
+        "digest": {
+          "sha256": "3b2729cfbd1a7d49811c3248b7d765534ca90e7232c831d1fffe250e50bae086"
+        },
+        "uri": "handover/evidence/risk-register.md"
+      },
+      {
+        "digest": {
+          "sha256": "0c3dc0c1ebdc13660d3a300b924d0bbb09ee353328f6b178c7a28403a3ef403f"
+        },
+        "uri": "handover/evidence/handover-operating-notes.md"
+      }
+    ],
+    "runDetails": {
+      "builder": {
+        "id": "local-codex-example"
+      },
+      "metadata": {
+        "invocationId": "local-gimmer-refuge-stage1-001",
+        "startedOn": "2026-07-04T21:29:35Z"
+      }
+    }
+  },
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "d924d607380b691e9d1a8c64c2dea8cf326a5b93d47b6686834c5fcdd7797b84"
+      },
+      "name": "handover/handover.json"
+    }
+  ]
+}

--- a/handover/stage-1-self-validating/handover/digests.json
+++ b/handover/stage-1-self-validating/handover/digests.json
@@ -1,0 +1,15 @@
+{
+  "digests": {
+    "access-logistics-and-rescue.md.sha256": "4ee464355550fdb16dca93c2810ca014b5ff43ef0b51668b5d9f8efddef3de88",
+    "cost-schedule-baseline.md.sha256": "8e96176c9b6ef4bf06529a8022d37537460113bdc1a0bd6b699d31af44bca634",
+    "environment-planning-note.md.sha256": "38f671ddff6a62de874d441363782612b8884e239aaa8e9d4082315e0a1fac74",
+    "handover-operating-notes.md.sha256": "0c3dc0c1ebdc13660d3a300b924d0bbb09ee353328f6b178c7a28403a3ef403f",
+    "risk-register.md.sha256": "3b2729cfbd1a7d49811c3248b7d765534ca90e7232c831d1fffe250e50bae086",
+    "site-context-and-constraints.md.sha256": "5f1d7134401a396cd317581333fc9264c585cbeb0ed58e155c59d67afcd1a9bd",
+    "stage-1-concept-design.md.sha256": "b497ef5f544420ffcd719436b5a6e2cc3aeb68392f05974defec9930d5839dc2",
+    "structural-safety-basis.md.sha256": "3b3143b3bab6823738f1097e30a5d2b5e200aa7651d425d33af91a4b3d5c42a8"
+  },
+  "evidence_dir": "handover/evidence",
+  "generated_at": "2026-07-04T21:29:35Z",
+  "schema": "https://example.org/schemas/handover-digests.schema.json"
+}

--- a/handover/stage-1-self-validating/handover/evidence/access-logistics-and-rescue.md
+++ b/handover/stage-1-self-validating/handover/evidence/access-logistics-and-rescue.md
@@ -1,0 +1,17 @@
+# Access Logistics And Rescue
+
+The Stage 1 access concept uses three routes:
+
+- normal foot approach for inspection and low-risk hand-carried materials
+- rope-access route for survey, anchor inspection, and protected work at the ledge
+- one controlled lift option for larger prefabricated components, subject to weather and environmental approval
+
+Emergency assumptions:
+
+- two-person minimum for rope-access work
+- rescue plan agreed before any Stage 2 intrusive survey
+- weather stop-work rule triggered by forecast gusts, poor visibility, or surface icing
+- material laydown kept below the crag until the ledge is verified as stable
+
+This is adequate for Stage 1 only. It is not a construction method statement.
+

--- a/handover/stage-1-self-validating/handover/evidence/cost-schedule-baseline.md
+++ b/handover/stage-1-self-validating/handover/evidence/cost-schedule-baseline.md
@@ -1,0 +1,18 @@
+# Cost Schedule Baseline
+
+Stage 1 range estimate:
+
+- Stage 2 survey and design: GBP 18k to GBP 32k
+- specialist access and safety planning: GBP 8k to GBP 15k
+- prototype/prefabrication allowance for later stage: GBP 45k to GBP 80k
+- contingency at this stage: 35 percent
+
+Indicative Stage 2 schedule:
+
+- survey and access plan: 3 weeks
+- anchor testing and environmental checks: 4 weeks
+- detailed design and independent review: 5 weeks
+- gateway pack refresh: 1 week
+
+The estimate is a decision envelope, not a delivery budget.
+

--- a/handover/stage-1-self-validating/handover/evidence/environment-planning-note.md
+++ b/handover/stage-1-self-validating/handover/evidence/environment-planning-note.md
@@ -1,0 +1,12 @@
+# Environment Planning Note
+
+Stage 1 planning assumptions:
+
+- small footprint with no permanent utility connection
+- visual impact reduced by low height and subdued materials
+- no lighting, signage, or commercial operation assumed
+- ecological walkover required before intrusive survey
+- landowner consent required before Stage 2 freeze
+
+The project remains conditional on land, planning, ecology, and access permissions. The current pack supports a gateway decision to continue design, not authority to build.
+

--- a/handover/stage-1-self-validating/handover/evidence/handover-operating-notes.md
+++ b/handover/stage-1-self-validating/handover/evidence/handover-operating-notes.md
@@ -1,0 +1,20 @@
+# Handover Operating Notes
+
+The next team inherits:
+
+- the Stage 1 concept and rejected options
+- the site and access assumptions
+- the evidence digest list
+- the Stage 1 signoffs and acceptance gates
+- the residual risks marked for Stage 2
+
+The next team must not assume:
+
+- construction is approved
+- anchor performance has been proven
+- final landowner consent has been granted
+- the estimate is a delivery budget
+- a weather window is guaranteed
+
+The pack is valid only when `handover.status` is `PASS`.
+

--- a/handover/stage-1-self-validating/handover/evidence/risk-register.md
+++ b/handover/stage-1-self-validating/handover/evidence/risk-register.md
@@ -1,0 +1,12 @@
+# Risk Register
+
+| ID | Risk | Stage 1 Rating | Treatment |
+| --- | --- | --- | --- |
+| R1 | Rock quality unsuitable for anchors | Amber | Carry to Stage 2 testing before design freeze |
+| R2 | Weather prevents safe survey windows | Amber | Plan seasonal windows and stop-work triggers |
+| R3 | Planning or land consent is narrower than assumed | Amber | Confirm permissions before detailed design freeze |
+| R4 | Visual impact objection | Amber | Keep profile low and prepare visual note |
+| R5 | Unclear operator ownership after build | Green | Client/Operator signoff required in this pack |
+
+There are no red risks accepted into the handover. Any red risk must force a FAIL until closed or downgraded with evidence.
+

--- a/handover/stage-1-self-validating/handover/evidence/site-context-and-constraints.md
+++ b/handover/stage-1-self-validating/handover/evidence/site-context-and-constraints.md
@@ -1,0 +1,17 @@
+# Site Context And Constraints
+
+Project: Gimmer Crag Mountain Refuge
+Stage: Stage 1 design
+
+The proposed refuge sits on a high ledge reached by a steep scramble and rope-access inspection route. Stage 1 assumes a small single-room shelter with no permanent services, no public road access, and only short-duration construction visits.
+
+Stage 1 constraints:
+
+- weather exposure is the dominant design driver
+- no loose rock is to be disturbed without a controlled method
+- the ledge footprint must remain within the existing disturbed area
+- all material movements must be reversible until Stage 2 approval
+- rescue access must remain clearer after the project than before it
+
+Stage 2 must confirm detailed topographic survey, anchor testing, and construction-season weather windows.
+

--- a/handover/stage-1-self-validating/handover/evidence/stage-1-concept-design.md
+++ b/handover/stage-1-self-validating/handover/evidence/stage-1-concept-design.md
@@ -1,0 +1,12 @@
+# Stage 1 Concept Design
+
+Preferred option: lightweight modular refuge with a small rectangular plan, low visual profile, timber or composite shell, and replaceable anchoring interface.
+
+Rejected Stage 1 options:
+
+- masonry hut: too much material handling and ledge disturbance
+- larger bothy-style shelter: too large for access, visual impact, and rescue assumptions
+- tent-platform only: does not meet weather refuge intent
+
+The concept is ready for Stage 2 development if anchor testing, planning advice, and environmental constraints remain within the current assumptions.
+

--- a/handover/stage-1-self-validating/handover/evidence/structural-safety-basis.md
+++ b/handover/stage-1-self-validating/handover/evidence/structural-safety-basis.md
@@ -1,0 +1,19 @@
+# Structural Safety Basis
+
+Stage 1 design basis:
+
+- wind exposure governs the shell and anchoring concept
+- snow and ice loads are treated as design cases for Stage 2
+- ledge bearing capacity is not assumed until verified
+- the refuge must fail safely under local component damage
+- every anchor detail must be inspectable and replaceable
+
+The pack does not approve construction. It records enough safety basis to pass from concept selection into detailed survey and Stage 2 design.
+
+Required Stage 2 evidence:
+
+- pull-out test plan and results
+- temporary works and rope-access method review
+- structural calculations for shell, base, and anchoring
+- independent check of the selected load cases
+

--- a/handover/stage-1-self-validating/handover/handover.json
+++ b/handover/stage-1-self-validating/handover/handover.json
@@ -1,0 +1,176 @@
+{
+  "handover_id": "gimmer-refuge-stage1-001",
+  "project": {
+    "name": "Gimmer Crag Mountain Refuge",
+    "asset": "single-room mountain refuge on a high ledge",
+    "location": "Gimmer Crag fictional training scenario",
+    "stage": "stage_1_design",
+    "description": "First stage design pack for a lightweight refuge reached by foot, rope-access survey, and staged material lifts."
+  },
+  "owner": "morgan.patel@example.org",
+  "prepared_at": "2026-07-04T12:00:00Z",
+  "decision": "stage_1_design_ready_for_gateway_review",
+  "signoff": [
+    {
+      "role": "Project Sponsor",
+      "by": "sponsor@example.org",
+      "at": "2026-07-04T12:10:00Z"
+    },
+    {
+      "role": "Design Lead",
+      "by": "design.lead@example.org",
+      "at": "2026-07-04T12:15:00Z"
+    },
+    {
+      "role": "Safety Lead",
+      "by": "safety.lead@example.org",
+      "at": "2026-07-04T12:20:00Z"
+    },
+    {
+      "role": "Client/Operator",
+      "by": "operator@example.org",
+      "at": "2026-07-04T12:25:00Z"
+    }
+  ],
+  "acceptance_gates": [
+    {
+      "id": "G1",
+      "title": "Site and constraints understood for Stage 1",
+      "owner": "Design Lead",
+      "outcome": "pass",
+      "evidence_refs": [
+        "EV-SITE-001",
+        "EV-ACCESS-001"
+      ]
+    },
+    {
+      "id": "G2",
+      "title": "Concept design is safe enough for Stage 2 development",
+      "owner": "Safety Lead",
+      "outcome": "pass",
+      "evidence_refs": [
+        "EV-CONCEPT-001",
+        "EV-STRUCT-001",
+        "EV-RISK-001"
+      ]
+    },
+    {
+      "id": "G3",
+      "title": "Planning, environment, cost, and schedule are bounded",
+      "owner": "Project Sponsor",
+      "outcome": "conditional_pass",
+      "evidence_refs": [
+        "EV-ENV-001",
+        "EV-COST-001",
+        "EV-HANDOVER-001"
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "id": "EV-SITE-001",
+      "name": "site-context-and-constraints.md",
+      "evidence_type": "site_context",
+      "path": "handover/evidence/site-context-and-constraints.md",
+      "digest_ref": "site-context-and-constraints.md.sha256",
+      "status": "accepted_for_stage_1",
+      "decision_use": "Defines terrain, weather, access assumptions, and non-negotiable constraints."
+    },
+    {
+      "id": "EV-ACCESS-001",
+      "name": "access-logistics-and-rescue.md",
+      "evidence_type": "access_logistics",
+      "path": "handover/evidence/access-logistics-and-rescue.md",
+      "digest_ref": "access-logistics-and-rescue.md.sha256",
+      "status": "accepted_for_stage_1",
+      "decision_use": "Shows how people, materials, emergency response, and inspections can reach the ledge."
+    },
+    {
+      "id": "EV-CONCEPT-001",
+      "name": "stage-1-concept-design.md",
+      "evidence_type": "concept_design",
+      "path": "handover/evidence/stage-1-concept-design.md",
+      "digest_ref": "stage-1-concept-design.md.sha256",
+      "status": "accepted_for_stage_1",
+      "decision_use": "Captures the preferred refuge option and alternatives rejected at Stage 1."
+    },
+    {
+      "id": "EV-STRUCT-001",
+      "name": "structural-safety-basis.md",
+      "evidence_type": "structural_safety",
+      "path": "handover/evidence/structural-safety-basis.md",
+      "digest_ref": "structural-safety-basis.md.sha256",
+      "status": "accepted_for_stage_1",
+      "decision_use": "Records the load, anchoring, and inspection basis for progressing design."
+    },
+    {
+      "id": "EV-ENV-001",
+      "name": "environment-planning-note.md",
+      "evidence_type": "environment_planning",
+      "path": "handover/evidence/environment-planning-note.md",
+      "digest_ref": "environment-planning-note.md.sha256",
+      "status": "accepted_for_stage_1",
+      "decision_use": "Lists planning, land, ecology, and visual-impact assumptions."
+    },
+    {
+      "id": "EV-COST-001",
+      "name": "cost-schedule-baseline.md",
+      "evidence_type": "cost_schedule",
+      "path": "handover/evidence/cost-schedule-baseline.md",
+      "digest_ref": "cost-schedule-baseline.md.sha256",
+      "status": "accepted_for_stage_1",
+      "decision_use": "Gives a bounded Stage 2 budget and schedule envelope."
+    },
+    {
+      "id": "EV-RISK-001",
+      "name": "risk-register.md",
+      "evidence_type": "risk_register",
+      "path": "handover/evidence/risk-register.md",
+      "digest_ref": "risk-register.md.sha256",
+      "status": "accepted_for_stage_1",
+      "decision_use": "Makes safety, weather, planning, and delivery risks visible before handover."
+    },
+    {
+      "id": "EV-HANDOVER-001",
+      "name": "handover-operating-notes.md",
+      "evidence_type": "handover_notes",
+      "path": "handover/evidence/handover-operating-notes.md",
+      "digest_ref": "handover-operating-notes.md.sha256",
+      "status": "accepted_for_stage_1",
+      "decision_use": "Explains what the next team inherits, owns, and must not assume."
+    }
+  ],
+  "residual_risks": [
+    {
+      "id": "RR-001",
+      "title": "Final rock anchor pull-out testing is not complete",
+      "severity": "amber",
+      "disposition": "carried_to_stage_2",
+      "owner": "Safety Lead"
+    },
+    {
+      "id": "RR-002",
+      "title": "Helicopter lift window remains weather dependent",
+      "severity": "amber",
+      "disposition": "carried_to_stage_2",
+      "owner": "Project Sponsor"
+    }
+  ],
+  "open_items": [
+    {
+      "id": "OI-001",
+      "title": "Confirm final landowner consent wording before detailed design freeze",
+      "severity": "watch",
+      "owner": "Client/Operator",
+      "due": "2026-07-31"
+    }
+  ],
+  "provenance": {
+    "subject": "handover/handover.json",
+    "attestation_type": "local-intoto-slsa-provenance",
+    "predicateType": "https://slsa.dev/provenance/v1",
+    "attestation_path": "handover/attestations/handover.intoto.json"
+  },
+  "release_note": "Stage 1 mountain refuge handover is acceptable only when validation writes PASS."
+}
+

--- a/handover/stage-1-self-validating/policy/handover.rego
+++ b/handover/stage-1-self-validating/policy/handover.rego
@@ -1,0 +1,96 @@
+package handover
+
+default allow := false
+
+required_roles := {
+  "Project Sponsor",
+  "Design Lead",
+  "Safety Lead",
+  "Client/Operator"
+}
+
+required_evidence_types := {
+  "site_context",
+  "access_logistics",
+  "concept_design",
+  "structural_safety",
+  "environment_planning",
+  "cost_schedule",
+  "risk_register",
+  "handover_notes"
+}
+
+allow if {
+  count(deny) == 0
+}
+
+deny contains "owner missing" if {
+  not input.owner
+}
+
+deny contains "minimum four signoffs required" if {
+  count(input.signoff) < 4
+}
+
+deny contains reason if {
+  role := required_roles[_]
+  not has_signoff_role(role)
+  reason := sprintf("missing required signoff role %q", [role])
+}
+
+deny contains reason if {
+  evidence_type := required_evidence_types[_]
+  not has_evidence_type(evidence_type)
+  reason := sprintf("missing required evidence type %q", [evidence_type])
+}
+
+deny contains reason if {
+  some i
+  ev := input.evidence[i]
+  ev.status != "accepted_for_stage_1"
+  reason := sprintf("evidence %q is not accepted for stage 1", [ev.id])
+}
+
+deny contains reason if {
+  some i
+  ev := input.evidence[i]
+  not data.digests[ev.digest_ref]
+  reason := sprintf("digest_ref %q not found in digests", [ev.digest_ref])
+}
+
+deny contains reason if {
+  some i
+  gate := input.acceptance_gates[i]
+  gate.outcome == "fail"
+  reason := sprintf("acceptance gate %q failed", [gate.id])
+}
+
+deny contains reason if {
+  some i
+  item := input.open_items[i]
+  item.severity == "blocker"
+  reason := sprintf("open item %q is a blocker", [item.id])
+}
+
+deny contains reason if {
+  some i
+  risk := input.residual_risks[i]
+  risk.severity == "red"
+  reason := sprintf("residual risk %q is red", [risk.id])
+}
+
+deny contains reason if {
+  input.provenance.predicateType != "https://slsa.dev/provenance/v1"
+  reason := "provenance predicateType is not SLSA provenance v1"
+}
+
+has_signoff_role(role) if {
+  some i
+  input.signoff[i].role == role
+}
+
+has_evidence_type(evidence_type) if {
+  some i
+  input.evidence[i].evidence_type == evidence_type
+}
+

--- a/handover/stage-1-self-validating/schema/digests.schema.json
+++ b/handover/stage-1-self-validating/schema/digests.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/handover-digests.schema.json",
+  "title": "Handover evidence digests",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generated_at",
+    "evidence_dir",
+    "digests"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "evidence_dir": {
+      "type": "string"
+    },
+    "digests": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    }
+  }
+}
+

--- a/handover/stage-1-self-validating/schema/handover.schema.json
+++ b/handover/stage-1-self-validating/schema/handover.schema.json
@@ -1,0 +1,314 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/mountain-refuge-handover.schema.json",
+  "title": "Mountain refuge stage handover",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "handover_id",
+    "project",
+    "owner",
+    "prepared_at",
+    "decision",
+    "signoff",
+    "acceptance_gates",
+    "evidence",
+    "residual_risks",
+    "open_items",
+    "provenance",
+    "release_note"
+  ],
+  "properties": {
+    "handover_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "asset",
+        "location",
+        "stage",
+        "description"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 3
+        },
+        "asset": {
+          "type": "string",
+          "minLength": 3
+        },
+        "location": {
+          "type": "string",
+          "minLength": 3
+        },
+        "stage": {
+          "type": "string",
+          "enum": [
+            "stage_1_design",
+            "stage_2_detailed_design",
+            "stage_3_build_readiness"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 10
+        }
+      }
+    },
+    "owner": {
+      "type": "string",
+      "format": "email"
+    },
+    "prepared_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "decision": {
+      "type": "string",
+      "minLength": 3
+    },
+    "signoff": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "role",
+          "by",
+          "at"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "minLength": 3
+          },
+          "by": {
+            "type": "string",
+            "format": "email"
+          },
+          "at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "acceptance_gates": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "owner",
+          "outcome",
+          "evidence_refs"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 2
+          },
+          "title": {
+            "type": "string",
+            "minLength": 5
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 3
+          },
+          "outcome": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "conditional_pass",
+              "fail"
+            ]
+          },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "name",
+          "evidence_type",
+          "path",
+          "digest_ref",
+          "status",
+          "decision_use"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "name": {
+            "type": "string",
+            "minLength": 3
+          },
+          "evidence_type": {
+            "type": "string",
+            "enum": [
+              "site_context",
+              "access_logistics",
+              "concept_design",
+              "structural_safety",
+              "environment_planning",
+              "cost_schedule",
+              "risk_register",
+              "handover_notes"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 3
+          },
+          "digest_ref": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]+\\.sha256$"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "accepted_for_stage_1",
+              "superseded"
+            ]
+          },
+          "decision_use": {
+            "type": "string",
+            "minLength": 10
+          }
+        }
+      }
+    },
+    "residual_risks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "severity",
+          "disposition",
+          "owner"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "green",
+              "amber",
+              "red"
+            ]
+          },
+          "disposition": {
+            "type": "string",
+            "enum": [
+              "accepted",
+              "carried_to_stage_2",
+              "blocked"
+            ]
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "open_items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "severity",
+          "owner",
+          "due"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "watch",
+              "action",
+              "blocker"
+            ]
+          },
+          "owner": {
+            "type": "string"
+          },
+          "due": {
+            "type": "string",
+            "format": "date"
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "subject",
+        "attestation_type",
+        "predicateType",
+        "attestation_path"
+      ],
+      "properties": {
+        "subject": {
+          "type": "string"
+        },
+        "attestation_type": {
+          "type": "string"
+        },
+        "predicateType": {
+          "type": "string"
+        },
+        "attestation_path": {
+          "type": "string"
+        }
+      }
+    },
+    "release_note": {
+      "type": "string",
+      "minLength": 5
+    }
+  }
+}
+

--- a/handover/stage-1-self-validating/scripts/create_local_attestation.py
+++ b/handover/stage-1-self-validating/scripts/create_local_attestation.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--handover", required=True)
+    parser.add_argument("--digests", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    handover_path = Path(args.handover)
+    digests_path = Path(args.digests)
+    output = Path(args.output)
+
+    handover = json.loads(handover_path.read_text(encoding="utf-8"))
+    digest_doc = json.loads(digests_path.read_text(encoding="utf-8"))
+    digests = digest_doc.get("digests", digest_doc)
+
+    materials = []
+    for evidence in handover["evidence"]:
+        digest_value = digests[evidence["digest_ref"]]
+        materials.append({
+            "uri": evidence["path"],
+            "digest": {
+                "sha256": digest_value
+            }
+        })
+
+    payload = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [
+            {
+                "name": str(handover_path),
+                "digest": {
+                    "sha256": sha256_file(handover_path)
+                }
+            }
+        ],
+        "predicateType": handover["provenance"]["predicateType"],
+        "predicate": {
+            "buildDefinition": {
+                "buildType": "https://example.org/handover/stage-1-design",
+                "externalParameters": {
+                    "handover_id": handover["handover_id"],
+                    "project": handover["project"]["name"],
+                    "stage": handover["project"]["stage"]
+                }
+            },
+            "runDetails": {
+                "builder": {
+                    "id": "local-codex-example"
+                },
+                "metadata": {
+                    "invocationId": f"local-{handover['handover_id']}",
+                    "startedOn": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+                }
+            },
+            "materials": materials
+        }
+    }
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Wrote local in-toto statement: {output}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/handover/stage-1-self-validating/scripts/update_digests.py
+++ b/handover/stage-1-self-validating/scripts/update_digests.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence-dir", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    evidence_dir = Path(args.evidence_dir)
+    output = Path(args.output)
+
+    if not evidence_dir.is_dir():
+        raise SystemExit(f"Evidence directory not found: {evidence_dir}")
+
+    digests = {}
+    for path in sorted(evidence_dir.iterdir()):
+        if path.is_file() and not path.name.startswith("."):
+            digests[f"{path.name}.sha256"] = sha256_file(path)
+
+    payload = {
+        "schema": "https://example.org/schemas/handover-digests.schema.json",
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "evidence_dir": str(evidence_dir),
+        "digests": digests,
+    }
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Wrote {output} with {len(digests)} evidence digests")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/handover/stage-1-self-validating/scripts/validate_handover.py
+++ b/handover/stage-1-self-validating/scripts/validate_handover.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+import argparse
+import copy
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REQUIRED_ROOT = {
+    "handover_id",
+    "project",
+    "owner",
+    "prepared_at",
+    "decision",
+    "signoff",
+    "acceptance_gates",
+    "evidence",
+    "residual_risks",
+    "open_items",
+    "provenance",
+    "release_note",
+}
+
+REQUIRED_ROLES = {
+    "Project Sponsor",
+    "Design Lead",
+    "Safety Lead",
+    "Client/Operator",
+}
+
+REQUIRED_EVIDENCE_TYPES = {
+    "site_context",
+    "access_logistics",
+    "concept_design",
+    "structural_safety",
+    "environment_planning",
+    "cost_schedule",
+    "risk_register",
+    "handover_notes",
+}
+
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def utc_now():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_json(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def iso_datetime(value):
+    if not isinstance(value, str):
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return True
+    except ValueError:
+        return False
+
+
+def inject_failure(handover, failure):
+    mutated = copy.deepcopy(handover)
+    if failure == "missing-safety-evidence":
+        mutated["evidence"] = [
+            ev for ev in mutated.get("evidence", [])
+            if ev.get("evidence_type") != "structural_safety"
+        ]
+    elif failure == "missing-signoff":
+        mutated["signoff"] = mutated.get("signoff", [])[:1]
+    elif failure == "bad-provenance":
+        mutated.setdefault("provenance", {})["predicateType"] = "https://example.org/not-slsa"
+    elif failure == "bad-digest-ref":
+        if mutated.get("evidence"):
+            mutated["evidence"][0]["digest_ref"] = "missing.sha256"
+    else:
+        raise SystemExit(f"Unknown injected failure: {failure}")
+    return mutated
+
+
+def schema_check(handover, schema):
+    del schema
+    deny = []
+    missing = sorted(REQUIRED_ROOT - set(handover))
+    for key in missing:
+        deny.append(f"schema: missing root field {key}")
+
+    project = handover.get("project", {})
+    if not isinstance(project, dict):
+        deny.append("schema: project must be an object")
+    else:
+        for key in ["name", "asset", "location", "stage", "description"]:
+            if not project.get(key):
+                deny.append(f"schema: project.{key} missing")
+        if project.get("stage") not in {"stage_1_design", "stage_2_detailed_design", "stage_3_build_readiness"}:
+            deny.append("schema: project.stage has invalid value")
+
+    if not EMAIL_RE.match(str(handover.get("owner", ""))):
+        deny.append("schema: owner must be an email address")
+
+    if not iso_datetime(handover.get("prepared_at")):
+        deny.append("schema: prepared_at must be date-time")
+
+    signoffs = handover.get("signoff", [])
+    if not isinstance(signoffs, list) or len(signoffs) < 4:
+        deny.append("schema: signoff must contain at least four entries")
+    else:
+        for idx, signoff in enumerate(signoffs):
+            if not signoff.get("role"):
+                deny.append(f"schema: signoff[{idx}].role missing")
+            if not EMAIL_RE.match(str(signoff.get("by", ""))):
+                deny.append(f"schema: signoff[{idx}].by must be email")
+            if not iso_datetime(signoff.get("at")):
+                deny.append(f"schema: signoff[{idx}].at must be date-time")
+
+    evidence = handover.get("evidence", [])
+    if not isinstance(evidence, list) or not evidence:
+        deny.append("schema: evidence must contain at least one entry")
+    else:
+        for idx, ev in enumerate(evidence):
+            for key in ["id", "name", "evidence_type", "path", "digest_ref", "status", "decision_use"]:
+                if not ev.get(key):
+                    deny.append(f"schema: evidence[{idx}].{key} missing")
+            if ev.get("evidence_type") not in REQUIRED_EVIDENCE_TYPES:
+                deny.append(f"schema: evidence[{idx}].evidence_type invalid")
+            if ev.get("status") not in {"draft", "accepted_for_stage_1", "superseded"}:
+                deny.append(f"schema: evidence[{idx}].status invalid")
+            if not str(ev.get("digest_ref", "")).endswith(".sha256"):
+                deny.append(f"schema: evidence[{idx}].digest_ref must end with .sha256")
+
+    for idx, gate in enumerate(handover.get("acceptance_gates", [])):
+        if gate.get("outcome") not in {"pass", "conditional_pass", "fail"}:
+            deny.append(f"schema: acceptance_gates[{idx}].outcome invalid")
+        if not gate.get("evidence_refs"):
+            deny.append(f"schema: acceptance_gates[{idx}].evidence_refs missing")
+
+    provenance = handover.get("provenance", {})
+    for key in ["subject", "attestation_type", "predicateType", "attestation_path"]:
+        if not provenance.get(key):
+            deny.append(f"schema: provenance.{key} missing")
+
+    return deny
+
+
+def policy_check(handover, digests):
+    deny = []
+    roles = {item.get("role") for item in handover.get("signoff", [])}
+    evidence_types = {item.get("evidence_type") for item in handover.get("evidence", [])}
+    evidence_ids = {item.get("id") for item in handover.get("evidence", [])}
+
+    for role in sorted(REQUIRED_ROLES - roles):
+        deny.append(f"policy: missing required signoff role {role}")
+
+    for evidence_type in sorted(REQUIRED_EVIDENCE_TYPES - evidence_types):
+        deny.append(f"policy: missing required evidence type {evidence_type}")
+
+    for ev in handover.get("evidence", []):
+        if ev.get("status") != "accepted_for_stage_1":
+            deny.append(f"policy: evidence {ev.get('id')} is not accepted for stage 1")
+        digest_ref = ev.get("digest_ref")
+        if digest_ref not in digests:
+            deny.append(f"policy: digest_ref {digest_ref} not found in digests")
+
+    for gate in handover.get("acceptance_gates", []):
+        if gate.get("outcome") == "fail":
+            deny.append(f"policy: acceptance gate {gate.get('id')} failed")
+        for evidence_ref in gate.get("evidence_refs", []):
+            if evidence_ref not in evidence_ids:
+                deny.append(f"policy: gate {gate.get('id')} references missing evidence {evidence_ref}")
+
+    for item in handover.get("open_items", []):
+        if item.get("severity") == "blocker":
+            deny.append(f"policy: open item {item.get('id')} is a blocker")
+
+    for risk in handover.get("residual_risks", []):
+        if risk.get("severity") == "red" or risk.get("disposition") == "blocked":
+            deny.append(f"policy: residual risk {risk.get('id')} blocks handover")
+
+    if handover.get("provenance", {}).get("predicateType") != "https://slsa.dev/provenance/v1":
+        deny.append("policy: provenance predicateType is not SLSA provenance v1")
+
+    return deny
+
+
+def digest_check(handover, digests):
+    deny = []
+    for ev in handover.get("evidence", []):
+        path = Path(ev.get("path", ""))
+        digest_ref = ev.get("digest_ref")
+        expected = digests.get(digest_ref)
+        if expected and not SHA256_RE.match(expected):
+            deny.append(f"digest: digest {digest_ref} is not a lowercase sha256")
+        if not path.exists():
+            deny.append(f"digest: evidence file not found {path}")
+            continue
+        actual = sha256_file(path)
+        if expected and actual != expected:
+            deny.append(f"digest: evidence file {path} does not match {digest_ref}")
+    return deny
+
+
+def provenance_check(handover, handover_path, attestation_path, digests, injected_failure):
+    deny = []
+    attestation_path = Path(attestation_path)
+    if not attestation_path.exists():
+        return [f"provenance: attestation not found {attestation_path}"]
+
+    attestation = load_json(attestation_path)
+    if attestation.get("_type") != "https://in-toto.io/Statement/v1":
+        deny.append("provenance: attestation is not an in-toto statement")
+    if attestation.get("predicateType") != handover.get("provenance", {}).get("predicateType"):
+        deny.append("provenance: predicateType does not match handover")
+
+    subjects = attestation.get("subject", [])
+    subject_digest = None
+    subject_name = None
+    if subjects:
+        subject_name = subjects[0].get("name")
+        subject_digest = subjects[0].get("digest", {}).get("sha256")
+    if subject_name != str(handover_path):
+        deny.append("provenance: subject name does not match handover path")
+
+    actual_handover_digest = sha256_json(handover) if injected_failure else sha256_file(handover_path)
+    if subject_digest != actual_handover_digest:
+        deny.append("provenance: subject digest does not match handover")
+
+    materials = {
+        item.get("uri"): item.get("digest", {}).get("sha256")
+        for item in attestation.get("predicate", {}).get("materials", [])
+    }
+    for ev in handover.get("evidence", []):
+        expected = digests.get(ev.get("digest_ref"))
+        material_digest = materials.get(ev.get("path"))
+        if material_digest != expected:
+            deny.append(f"provenance: material for {ev.get('path')} missing or digest mismatch")
+
+    return deny
+
+
+def write_status(status_path, status_json_path, payload):
+    Path(status_path).write_text(payload["status"] + "\n", encoding="utf-8")
+    Path(status_json_path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--handover", required=True)
+    parser.add_argument("--digests", required=True)
+    parser.add_argument("--attestation", required=True)
+    parser.add_argument("--schema", required=True)
+    parser.add_argument("--status", default="handover.status")
+    parser.add_argument("--status-json", default="handover.status.json")
+    parser.add_argument("--inject-failure", choices=[
+        "missing-safety-evidence",
+        "missing-signoff",
+        "bad-provenance",
+        "bad-digest-ref",
+    ])
+    parser.add_argument("--expect-fail", action="store_true")
+    args = parser.parse_args()
+
+    handover_path = Path(args.handover)
+    handover = load_json(handover_path)
+    schema = load_json(args.schema)
+    digest_doc = load_json(args.digests)
+    digests = digest_doc.get("digests", digest_doc)
+
+    if args.inject_failure:
+        handover = inject_failure(handover, args.inject_failure)
+
+    checks = {
+        "schema": schema_check(handover, schema),
+        "policy": policy_check(handover, digests),
+        "digests": digest_check(handover, digests),
+        "provenance": provenance_check(handover, handover_path, args.attestation, digests, args.inject_failure),
+    }
+
+    deny = []
+    for group in ["schema", "policy", "digests", "provenance"]:
+        deny.extend(checks[group])
+
+    status = "PASS" if not deny else "FAIL"
+    payload = {
+        "status": status,
+        "checked_at": utc_now(),
+        "handover_id": handover.get("handover_id"),
+        "project": handover.get("project", {}).get("name"),
+        "injected_failure": args.inject_failure,
+        "checks": {
+            key: {
+                "status": "PASS" if not value else "FAIL",
+                "deny": value
+            }
+            for key, value in checks.items()
+        },
+        "deny": deny,
+    }
+    write_status(args.status, args.status_json, payload)
+
+    print(f"Handover validation: {status}")
+    if deny:
+        for reason in deny:
+            print(f"- {reason}")
+
+    if args.expect_fail:
+        if status == "FAIL":
+            return 0
+        print("Expected validation to fail, but it passed")
+        return 1
+
+    return 0 if status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
## What changed

Adds a runnable Stage 1 self-validating handover pack for the Gimmer Crag mountain-refuge scenario under `handover/stage-1-self-validating/`.

The pack includes:

- a declarative `handover.json` with project metadata, signoffs, gates, evidence, residual risks, open items, and provenance
- evidence stubs plus generated SHA256 digests
- a local in-toto/SLSA-style provenance statement
- JSON schemas, an OPA/Rego policy, and Python helper scripts
- a `Makefile` with `refresh`, `validate`, `validate-opa`, and `fail-demo` targets
- a GitHub Actions workflow that validates the nested pack and uploads the status artifact

## Why

This turns the handover idea into something that can be tried: the pack writes `PASS` only when the evidence, policy, digests, and provenance checks line up, and it deliberately demonstrates fail-closed behaviour when required evidence is removed.

## Validation

Run in the repo checkout:

- `make refresh` from `handover/stage-1-self-validating` -> PASS
- `make fail-demo` from `handover/stage-1-self-validating` -> expected FAIL for missing structural safety evidence
- `make validate-opa OPA=/private/tmp/opa` from `handover/stage-1-self-validating` -> `[]` policy denials

Note: local `gh auth status` reported an invalid saved token, but branch push succeeded through git credentials.